### PR TITLE
bug: 뉴스 상세페이지에서 대륙별 카테고리 필터링 기능 구현

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -23,7 +23,7 @@ export default function Header({ status }: { status: HeaderStatusType }) {
   }
   return (
     <>
-      <div className="fixed top-0 w-full z-50">
+      <div className="fixed top-0 z-50 w-full">
         {status === "landing" ? (
           <div className="w-full h-[80px] flex max-md:px-[12px] px-[40px] max-md:h-[40px] justify-between items-center bg-black01 text-white">
             <img
@@ -69,13 +69,13 @@ export default function Header({ status }: { status: HeaderStatusType }) {
                     : "w-[360px] max-md:w-[180px]"
                 } flex h-[29px] justify-between text-[24px] max-md:text-[12px] items-center font-sofiaSans text-black01`}
               >
-                <Link to={"/news"}>News</Link>
+                <Link to={"/news?continent=all"}>News</Link>
                 <Link to={"/debate-rooms"}>Debate Rooms</Link>
                 <Link to={"/debaters"}>Debaters</Link>
                 {status === "admin" ? <Link to={"/admin"}>Admin</Link> : ""}
               </div>
             </div>
-            <div className="flex items-center md:space-x-4 space-x-1">
+            <div className="flex items-center space-x-1 md:space-x-4">
               <button
                 onClick={() => setIsNotificationOpen(!isNotificationOpen)}
               >

--- a/src/components/news/NewsList.tsx
+++ b/src/components/news/NewsList.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useRef } from "react";
 import bookmark from "../../assets/icons/bookmark.svg";
-import connection from "../../assets/icons/connection.svg";
 import like from "../../assets/icons/like.svg";
 import TopButton from "../common/TopButton";
 
@@ -33,12 +32,16 @@ export default function NewsList({
               alt="뉴스 이미지"
               className="object-cover w-full h-48 rounded-lg"
             />
-            <h3 className="mt-3 text-lg font-extrabold h-[56px]">{news.title}</h3>
+            <h3 className="mt-3 text-lg font-extrabold h-[56px]">
+              {news.title}
+            </h3>
             <div className="flex justify-between mt-2 text-sm text-gray-500">
               <p>{news.newsType}</p>
               <p>{new Date(news.deliveryTime).toLocaleString()}</p>
             </div>
-            <p className="mt-2 text-sm text-gray-700 h-[220px]">{news.content}</p>
+            <p className="mt-2 text-sm text-gray-700 h-[220px]">
+              {news.content}
+            </p>
             <div className="flex items-center justify-end mt-3 text-sm text-gray-500">
               <div className="flex space-x-3">
                 <img src={like} alt="좋아요" className="w-5 h-5" />

--- a/src/components/news/category.tsx
+++ b/src/components/news/category.tsx
@@ -1,13 +1,9 @@
-import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router";
 
-const Category = ({
-  continentCodeChange,
-}: {
-  continentCodeChange: (code: string) => void;
-}) => {
-
-  const [code, setCode] = useState("all");
-
+const Category = () => {
+  const [serchParams] = useSearchParams();
+  const continentCode = serchParams.get("continent");
+  const navigate = useNavigate();
   const categories = [
     { name: "전체보기", code: "all" },
     { name: "한국", code: `KR` },
@@ -19,28 +15,22 @@ const Category = ({
     { name: "아프리카/중동", code: `AF` },
   ];
 
-  const continentCode = (code: string) => {
-    continentCodeChange(code);
-  };
-
-
   return (
     <div className="w-full text-left text-gray-400 rounded-md md:border md:p-4">
       <div className="mb-2 text-lg font-extrabold text-blue03 md:p-2 font-pretendard">
         카테고리
       </div>
 
-      {/* PC 일때때 */}
+      {/* PC */}
       <div className="hidden md:block">
         {categories.map((category, index) => (
           <div
             key={index}
             className={`${
-              code === category.code ? "text-blue03" : "text-gray-500"
+              continentCode === category.code ? "text-blue03" : "text-gray-500"
             } px-4 py-2 font-bold  transition-colors hover:bg-gray02 rounded-md cursor-pointer font-pretendard hover:text-blue03`}
             onClick={() => {
-              continentCode(category.code);
-              setCode(category.code);
+              navigate(`/news?continent=${category.code}`);
             }}
           >
             {category.name}
@@ -48,19 +38,18 @@ const Category = ({
         ))}
       </div>
 
-      {/* 모바일 일때 */}
+      {/* 모바일 */}
       <div className="block mb-5 overflow-x-auto md:hidden whitespace-nowrap scroll">
         <div className="flex gap-3">
           {categories.map((category, index) => (
             <div
               key={index}
               className={`${
-                code === category.code ? "text-blue03" : "text-gray-500"
+                continentCode === category.code
+                  ? "text-blue03"
+                  : "text-gray-500"
               } px-4 py-2 font-bold  transition-colors bg-gray-100 rounded-md cursor-pointer font-pretendard hover:text-blue03`}
-              onClick={() => {
-                continentCode(category.code);
-                setCode(category.code);
-              }}
+              onClick={() => {}}
             >
               {category.name}
             </div>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -85,7 +85,7 @@ export default function Main() {
                 Focus
               </span>
               <Link
-                to={tab ? "/news" : "/debate-rooms"}
+                to={tab ? "/news?continent=all" : "/debate-rooms"}
                 className="w-[112px] h-[34px] text-[20px] max-lg:text-[16px] max-md:text-[12px] max-md:w-[66px] max-md:h-[18px] bg-gray03 rounded-[10px] text-white justify-center items-center flex"
               >
                 view more

--- a/src/pages/News.tsx
+++ b/src/pages/News.tsx
@@ -5,10 +5,12 @@ import NewsList from "../components/news/NewsList";
 import FilterSearchSkeleton from "../components/common/skeleton/news/FilterSearchSkeleton";
 import { newsAPI } from "../api/news";
 import Category from "../components/news/Category";
-
+import { useSearchParams } from "react-router";
 
 export default function News() {
-  const [currentContinent, setCurrentContinent] = useState("all"); // 대륙 상태 저장
+  const [serchParams] = useSearchParams();
+  const continentCode = serchParams.get("continent");
+
   const [isLoading, setIsLoading] = useState(true);
   const [newsData, setNewsData] = useState<NewsType[]>([]);
   const [text, setText] = useState("");
@@ -23,17 +25,12 @@ export default function News() {
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Enter") {
-      fetchAllNews(currentSort, true, currentContinent ?? undefined); // null -> undefined 변환
+      fetchAllNews(currentSort, true, continentCode ?? undefined); // null -> undefined 변환
     }
   };
 
   const textValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setText(e.target.value);
-  };
-
-  const continentCodeChange = (code: string) => {
-    setCurrentContinent(code);
-    fetchAllNews(currentSort, true, code); // 새로운 대륙에 맞춰 뉴스 데이터 불러오기
   };
 
   const fetchAllNews = async (
@@ -52,7 +49,6 @@ export default function News() {
         setCursor(null);
         setCurrentSearchTerm(text);
         setCurrentSort(actualSort);
-        setCurrentContinent(continent ?? currentContinent);
       }
 
       const cursorValue = cursor && !isNewSearch ? cursor : undefined;
@@ -89,11 +85,11 @@ export default function News() {
   };
 
   useEffect(() => {
-    fetchAllNews(currentSort, true, currentContinent);
-  }, [currentContinent]);
+    fetchAllNews(currentSort, true, continentCode!);
+  }, [continentCode]);
 
   useEffect(() => {
-    fetchAllNews(currentSort, true, currentContinent);
+    fetchAllNews(currentSort, true, continentCode!);
   }, [currentSort]);
 
   useEffect(() => {
@@ -120,7 +116,7 @@ export default function News() {
       <div className="flex flex-col h-full p-6 mx-auto overflow-auto max-w-10xl md:flex-row md:pr-0 md:gap-6">
         {/* 카테고리 */}
         <div className="order-1 w-full md:w-1/6 md:ml-3 md:order-1">
-          <Category continentCodeChange={continentCodeChange} />
+          <Category />
         </div>
 
         <div className="order-2 overflow-auto md:w-5/6 md:mr-3 md:order-2">
@@ -169,11 +165,7 @@ export default function News() {
                 />
                 <button
                   onClick={() =>
-                    fetchAllNews(
-                      currentSort,
-                      true,
-                      currentContinent ?? undefined
-                    )
+                    fetchAllNews(currentSort, true, continentCode ?? undefined)
                   }
                 >
                   <img


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
- close #161 
## 📝 요약(Summary)
뉴스 상세페이지에서 대륙별 카테고리 필터링 기능 구현
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
