### PR TITLE
feat: follow throttling 처리

### DIFF
--- a/src/hooks/useThrottle.tsx
+++ b/src/hooks/useThrottle.tsx
@@ -1,0 +1,15 @@
+import { useRef } from "react";
+
+const useThrottle = (callback: Function, delay: number) => {
+    const lastExecuted = useRef<number>(0);
+  
+    return (...args: any[]) => {
+      const now = Date.now();
+      if (now - lastExecuted.current >= delay) {
+        callback(...args);
+        lastExecuted.current = now;
+      }
+    };
+  };
+
+export default useThrottle

--- a/src/pages/UserPage.tsx
+++ b/src/pages/UserPage.tsx
@@ -12,6 +12,7 @@ import { useAuthStore } from "../stores/authStore";
 import { useModalStore } from "../stores/useModal";
 import logoutSVG from "../assets/icons/logout.svg";
 import logoutHover from "../assets/icons/logoutHover.svg";
+import useThrottle from "../hooks/useThrottle";
 
 export default function UserPage() {
   const [tab, setTab] = useState("news");
@@ -48,24 +49,18 @@ export default function UserPage() {
     console.log(user);
   }, [user]);
 
-  const handleFollow = async (
-    targetUserId: number,
-    action: "delete" | "follow"
-  ) => {
-    if (!currentUserId) return;
+
+  const handleFollow = async (targetUserId: number, action: "delete" | "follow") => {
     action === "delete"
       ? await userApi.deleteFollower(targetUserId)
       : await userApi.insertFollower(targetUserId);
+      setFollowing(action === "follow");
   };
 
-  const handleClickFollowWithPrevent = usePreventDoubleClick<
-    (id: number, action: "delete" | "follow") => void
-  >(handleFollow, 300);
-  const toggleFollow = async () => {
-    isFollowed
-      ? handleClickFollowWithPrevent(Number(userId), "delete")
-      : handleClickFollowWithPrevent(Number(userId), "follow");
-    setFollowing(!isFollowed);
+  const throttledFollow = useThrottle(handleFollow, 1000)
+
+  const toggleFollow = () => {
+    throttledFollow(userId, isFollowed ? "delete" : "follow");
   };
 
   // 해당 프로필 페이지의 유저를 현재 유저가 팔로우 했는지 안했는지 가져오는 함수


### PR DESCRIPTION
## #️⃣ Issue Number

#181
- close #181
- 
## 📝 요약(Summary)
- 원래 디바운싱 처리 한 코드를 쓰로틀링이 더 적합하다고 판단하여 수정하였습니다.
- 디바운싱은 특정 시간 동안 입력이 없을 때 한 번만 실행되도록 하는 방식이라, 여러 번 연속으로 클릭할 경우 최종 클릭만 반영
- 그러나 팔로우 기능에서는 사용자가 여러 번 클릭해도 "최초 클릭 후 일정 시간 동안 추가 요청을 막는 것"이 더 적절

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)
<img width="952" alt="image" src="https://github.com/user-attachments/assets/15f3421f-61a4-4ff6-8490-892a062abe83" />

## 💬 공유사항 to 리뷰어

usePreventdoubleClick 이라는 코드로 팔로우 디바운싱을 처리하고 있었는데 이 커스텀 훅을 사용하시는/ 사용하실 분이 없다면 삭제하겠습니다

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
